### PR TITLE
Make widget look like other status bar widgets

### DIFF
--- a/lib/scroll-percentage.coffee
+++ b/lib/scroll-percentage.coffee
@@ -8,7 +8,8 @@ module.exports = ScrollPercentage =
 
   consumeStatusBar: (statusBar) ->
     scrollLabel = document.createElement 'span'
-    scrollLabel.className = 'scroll-percentage';
+    scrollLabel.id = 'scroll-percentage';
+    scrollLabel.className = 'inline-block';
     scrollLabel.textContent = @formatLabel 0
 
     @statusBarTile = statusBar.addRightTile

--- a/styles/scroll-percentage.less
+++ b/styles/scroll-percentage.less
@@ -1,5 +1,3 @@
-.scroll-percentage {
+#scroll-percentage {
   color: white;
-  position: fixed;
-  padding-left: 15px;
 }


### PR DESCRIPTION
Hey, first off, nice plugin! :)
I ran into a little problem though:
![screen shot 2016-02-25 at 13 08 06](https://cloud.githubusercontent.com/assets/5417774/13320030/30b7e990-dbc6-11e5-814d-163afe442549.png)
So I played around a little with the CSS attributes and found out that the culprit was `position: fixed`.
I'm a little confused as to why you choose to use that in the first place. Why not just the `inline-block` class to make it look like the other widgets?
I also thought it would be more appropriate to use `scroll-percentage` as the ID and not the class name since it's only supposed to appear once in the code, right?
Anyway, let me know what you think and keep up the good work! :)
(I wasn't sure whether to send this as a pull request or file an issue.)
